### PR TITLE
JENKINS-227: uploadFileToWeb: Fail build if upload fails

### DIFF
--- a/vars/uploadFileToWeb.groovy
+++ b/vars/uploadFileToWeb.groovy
@@ -4,5 +4,12 @@ def call(def localfile, def upload)
 {
 	echo "Uploading file '${localfile}' to WEB"
 	// +x, otherwise we would spoil the upload token
-	sh "set +x; curl -X POST -k -F upload=@${localfile} '${upload}'"
+	def httpStatus = sh script: "set +x; curl --write-out %{http_code} --silent --output /dev/stderr -X POST -k -F upload=@${localfile} '${upload}'", returnStdout: true
+	// HTTP status code for HTTP OK is 200
+	if (httpStatus == "200") {
+		echo "Upload successful: curl reported HTTP status code: ${httpStatus}"
+	} else {
+		echo "Upload failed: curl reported HTTP status code: ${httpStatus}"
+		currentBuild.result = 'FAILURE'
+	}
 }


### PR DESCRIPTION
curl does not fail if it retrieves a proper HTTP response. Which means that curl does not fail (return code != 0) even if the returned HTTP status code is != HTTP OK (200).
To detect failed uploads to WEB, curl prints the HTTP status code to stdout (normal stdout is redirected to stderr, to still see, what's going on) and if the status code is != 200, the build is marked as failed (as the job can't fulfill the intended purpose).